### PR TITLE
OutList->^OutList in InnerRequest schema

### DIFF
--- a/types.tlb
+++ b/types.tlb
@@ -23,7 +23,7 @@ internal_signed#73696e74 signed:SignedRequest = InternalMsgBody;
 internal_extension#6578746e query_id:(## 64) inner:InnerRequest = InternalMsgBody;
 external_signed#7369676e signed:SignedRequest = ExternalMsgBody;
 
-actions$_ out_actions:(Maybe OutList) has_other_actions:(## 1) {m:#} {n:#} other_actions:(ActionList n m) = InnerRequest;
+actions$_ out_actions:(Maybe ^OutList) has_other_actions:(## 1) {m:#} {n:#} other_actions:(ActionList n m) = InnerRequest;
 
 // Contract state
 contract_state$_ is_signature_allowed:(## 1) seqno:# wallet_id:(## 32) public_key:(## 256) extensions_dict:(HashmapE 256 int1) = ContractState;


### PR DESCRIPTION
[example_tx](https://tonviewer.com/transaction/b4c5eddc52d0e23dafb2da6d022a5b6ae7eba52876fa75d32b2a95fa30c7e2f0)

body_boc: `b5ee9c720101040100940001a17369676e7fffff11ffffffff00000000bc04889cb28b36a3a00810e363a413763ec34860bf0fce552c5d36e37289fafd442f1983d740f92378919d969dd530aec92d258a0779fb371d4659f10ca1b3826001020a0ec3c86d030302006642007847b4630eb08d9f486fe846d5496878556dfd5a084f82a9a3fb01224e67c84c187a1200000000000000000000000000000000`

cell tree:

```
Cell x{Type: Ordinary, data: [7369676E7FFFFF11FFFFFFFF00000000BC04889CB28B36A3A00810E363A413763EC34860BF0FCE552C5D36E37289FAFD442F1983D740F92378919D969DD530AEC92D258A0779FB371D4659F10CA1B38240_], bit_len: 642, references: [
    Cell x{Type: Ordinary, data: [0EC3C86D03], bit_len: 40, references: [
        Cell {Type: Ordinary, data: [], bit_len: 0, refs: []}
        Cell {Type: Ordinary, data: [42007847B4630EB08D9F486FE846D5496878556DFD5A084F82A9A3FB01224E67C84C187A120000000000000000000000000000], bit_len: 408, refs: []}
    ]}
]}

```

So first (and only one) action is stored in CellRef

According to [OutList schema](https://github.com/ton-blockchain/ton/blob/cee4c674ea999fecc072968677a34a7545ac9c4d/crypto/block/block.tlb#L389), it's last action is stored right in OutList Cell -> We have ^OutList 
